### PR TITLE
Made some performance enhancements

### DIFF
--- a/src/components/Programs.tsx
+++ b/src/components/Programs.tsx
@@ -393,13 +393,15 @@ const Programs = () => {
                   </div>
                 </div>
                 <div className={openTab === 3 ? 'lg:hidden flex py-10' : 'hidden'} id="link3">
-                  <iframe
-                    className="linkedin"
-                    src="https://www.linkedin.com/embed/feed/update/urn:li:share:6759920948922732544"
-                    frameBorder="0"
-                    allowFullScreen={false}
-                    title="Embedded post"
-                  />
+                  {openTab === 3 && (
+                    <iframe
+                      className="linkedin"
+                      src="https://www.linkedin.com/embed/feed/update/urn:li:share:6759920948922732544"
+                      frameBorder="0"
+                      allowFullScreen={false}
+                      title="Embedded post"
+                    />
+                  )}
                 </div>
               </li>
             </ul>
@@ -677,13 +679,15 @@ const Programs = () => {
           </div>
         </div>
         <div className={openTab === 3 ? 'hidden lg:flex lg:items-center' : 'hidden'} id="link3">
-          <iframe
-            className="pl-8 linkedin"
-            src="https://www.linkedin.com/embed/feed/update/urn:li:share:6759920948922732544"
-            frameBorder="0"
-            allowFullScreen={false}
-            title="Embedded post"
-          />
+          {openTab === 3 && (
+            <iframe
+              className="pl-8 linkedin"
+              src="https://www.linkedin.com/embed/feed/update/urn:li:share:6759920948922732544"
+              frameBorder="0"
+              allowFullScreen={false}
+              title="Embedded post"
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/libs/utils/deferScripts.tsx
+++ b/src/libs/utils/deferScripts.tsx
@@ -1,0 +1,68 @@
+// eslint-disable-next-line @next/next/no-document-import-in-page
+import { NextScript } from 'next/document'
+
+function dedupe<T extends { file: string }>(bundles: any[]): T[] {
+  const files = new Set<string>()
+  const kept: T[] = []
+
+  for (const bundle of bundles) {
+    if (files.has(bundle.file)) continue
+    files.add(bundle.file)
+    kept.push(bundle)
+  }
+  return kept
+}
+
+type DocumentFiles = {
+  sharedFiles: readonly string[]
+  pageFiles: readonly string[]
+  allFiles: readonly string[]
+}
+
+/**
+ * Custom NextScript to defer loading of unnecessary JS.
+ * Standard behavior is async. Compatible with Next.js 10.0.3
+ */
+class DeferNextScript extends NextScript {
+  getDynamicChunks(files: DocumentFiles) {
+    const { dynamicImports, assetPrefix, isDevelopment, devOnlyCacheBusterQueryString } =
+      this.context
+
+    return dedupe(dynamicImports).map((bundle) => {
+      if (!bundle.file.endsWith('.js') || files.allFiles.includes(bundle.file)) return null
+
+      return (
+        <script
+          defer={!isDevelopment}
+          key={bundle.file}
+          src={`${assetPrefix}/_next/${encodeURI(bundle.file)}${devOnlyCacheBusterQueryString}`}
+          nonce={this.props.nonce}
+          crossOrigin={this.props.crossOrigin || process.env.__NEXT_CROSS_ORIGIN}
+        />
+      )
+    })
+  }
+  getScripts(files: DocumentFiles) {
+    const { assetPrefix, buildManifest, isDevelopment, devOnlyCacheBusterQueryString } =
+      this.context
+
+    const normalScripts = files.allFiles.filter((file) => file.endsWith('.js'))
+    const lowPriorityScripts = buildManifest.lowPriorityFiles?.filter((file) =>
+      file.endsWith('.js')
+    )
+
+    return [...normalScripts, ...lowPriorityScripts].map((file) => {
+      return (
+        <script
+          key={file}
+          src={`${assetPrefix}/_next/${encodeURI(file)}${devOnlyCacheBusterQueryString}`}
+          nonce={this.props.nonce}
+          defer={!isDevelopment}
+          crossOrigin={this.props.crossOrigin || process.env.__NEXT_CROSS_ORIGIN}
+        />
+      )
+    })
+  }
+}
+
+export default DeferNextScript

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,5 @@
-import Document, { Head, Html, Main, NextScript } from 'next/document'
+import DeferNextScript from '@/libs/utils/deferScripts'
+import Document, { Head, Html, Main } from 'next/document'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: any) {
@@ -18,7 +19,7 @@ class MyDocument extends Document {
         </Head>
         <body className="antialiased text-black">
           <Main />
-          <NextScript />
+          <DeferNextScript />
         </body>
       </Html>
     )


### PR DESCRIPTION
Made two minor tweaks that improved performance in the lighthouse report. Below is the local lighthouse report, left is before, right is after.

<div display="flex">
<img src="https://user-images.githubusercontent.com/50402712/145765073-1aaafa03-6d8b-4973-a46b-a6f8e4710819.png" width="250"/>
<img src="https://user-images.githubusercontent.com/50402712/145765184-e628cdf9-6a95-42ed-8604-3a827fd9fe98.png" width="250"/>

What i did was that i created a util that defers loading scripts which improve FCP, and i also noticed that there is a lot of errors in the console, these errors comes from the linked in iframes, the best thing would be to implement them in another way, but the fix for now is to only load them when they will be shown, this improves the initial load of the website and prevents the errors to occur before we want to show the iframe.

</div>